### PR TITLE
remove ember-cli-htmlbars as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "prepublishOnly": "yarn build:ts"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.26.3",
-    "ember-cli-htmlbars": "^5.7.1"
+    "ember-cli-babel": "^7.26.3"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
This addon doesn't have any hbs files so this didn't need to be a dependency 🙈 